### PR TITLE
Implement per-farm training option

### DIFF
--- a/model_rainfall.py
+++ b/model_rainfall.py
@@ -16,6 +16,7 @@ Adjust station name, date range, or scaling method as needed.
 import pickle
 import os
 import math
+import logging
 import numpy as np
 import pandas as pd
 from datetime import datetime
@@ -35,6 +36,10 @@ import tensorflow.keras.backend as K
 
 # Matplotlib
 import matplotlib.pyplot as plt
+
+# Configure logging
+logging.basicConfig(format='[%(levelname)s] %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # -------------------------------
 # 1. Configuration
@@ -58,6 +63,14 @@ STATION_FOLDERS = [
     "Hirako_Farm1",                  # Second instance of Hirako Farm
     "Anoano_Farms"                   # From Anoano Farms
 ]
+
+# Train models individually for each farm when True. When False, all data is
+# combined as before.
+TRAIN_PER_FARM = False
+
+# Directory to store trained models and scalers when TRAIN_PER_FARM is enabled
+MODELS_DIR = "models"
+os.makedirs(MODELS_DIR, exist_ok=True)
 
 # Base directory for station folders
 BASE_DIR = "farm_data"
@@ -114,7 +127,7 @@ def load_station_data(station_folder):
     """
     csv_path = os.path.join(BASE_DIR, station_folder, "all_years_data.csv")
     if not os.path.exists(csv_path):
-        print(f"Warning: {csv_path} not found. Station: {station_folder}")
+        logger.warning(f"{csv_path} not found. Station: {station_folder}")
         return pd.DataFrame()  # empty
 
     df = pd.read_csv(csv_path)
@@ -269,11 +282,150 @@ def plot_training_history(history, save_path):
     plt.close()
 
 # -------------------------------
+# 4. Per-Farm Training Function
+# -------------------------------
+def train_for_station(station_folder):
+    """Train and evaluate a rainfall model for a single farm."""
+    logger.info(f"Training rainfall model for {station_folder}")
+    df_station = load_station_data(station_folder)
+    if df_station.empty:
+        logger.info(f"No data for station {station_folder}. Skipping.")
+        return
+
+    df_train, df_test = split_test_by_date(
+        df_station,
+        station_folder,
+        station_folder,
+        TEST_START,
+        TEST_END,
+    )
+
+    df_train = feature_engineering(df_train)
+    df_test = feature_engineering(df_test)
+
+    if df_train.empty:
+        logger.info(f"No training data for station {station_folder}. Skipping.")
+        return
+
+    scaler = StandardScaler()
+    scaler.fit(df_train.values)
+
+    scaler_path = os.path.join(MODELS_DIR, f"{station_folder}_scaler_Rain.pkl")
+    with open(scaler_path, "wb") as f:
+        pickle.dump(scaler, f)
+
+    df_train_scaled = pd.DataFrame(
+        scaler.transform(df_train.values), columns=df_train.columns
+    )
+
+    X_train_full, y_train_full = create_sequences(
+        df_train_scaled,
+        window_size=WINDOW_SIZE,
+        horizon=HORIZON,
+        target_col=TARGET_COL,
+    )
+
+    indices = np.arange(len(X_train_full))
+    np.random.shuffle(indices)
+    X_train_full = X_train_full[indices]
+    y_train_full = y_train_full[indices]
+
+    train_size = int(TRAIN_VAL_RATIO * len(X_train_full))
+    X_val = X_train_full[train_size:]
+    y_val = y_train_full[train_size:]
+    X_train = X_train_full[:train_size]
+    y_train = y_train_full[:train_size]
+
+    num_features = df_train.shape[1]
+    model = Sequential()
+    model.add(LSTM(64, activation="tanh", input_shape=(WINDOW_SIZE, num_features)))
+    model.add(Dense(HORIZON))
+    model.compile(
+        loss="mse",
+        optimizer=Adam(learning_rate=0.001),
+        metrics=["mae", r2_keras],
+    )
+
+    early_stop = EarlyStopping(monitor="val_loss", patience=5, restore_best_weights=True)
+
+    history = model.fit(
+        X_train,
+        y_train,
+        validation_data=(X_val, y_val),
+        epochs=50,
+        batch_size=32,
+        callbacks=[early_stop],
+        verbose=0,
+    )
+
+    model_path = os.path.join(MODELS_DIR, f"{station_folder}_model_rain_lstm.h5")
+    model.save(model_path)
+    logger.info(f"Model saved: {model_path}")
+
+    station_plot_dir = os.path.join(PLOTS_DIR, station_folder)
+    os.makedirs(station_plot_dir, exist_ok=True)
+
+    history_csv_path = os.path.join(station_plot_dir, "training_history_values.csv")
+    pd.DataFrame(history.history).to_csv(history_csv_path, index=False)
+
+    plot_history_path = os.path.join(station_plot_dir, "training_history.png")
+    plot_training_history(history, plot_history_path)
+    logger.info(f"Artifacts saved to {station_plot_dir}")
+
+    if not df_test.empty:
+        df_test_scaled = pd.DataFrame(
+            scaler.transform(df_test.values), columns=df_test.columns
+        )
+        X_test, y_test = create_sequences(
+            df_test_scaled,
+            window_size=WINDOW_SIZE,
+            horizon=HORIZON,
+            target_col=TARGET_COL,
+        )
+        if len(X_test) > 0:
+            y_test_pred_scaled = model.predict(X_test)
+
+            df_cols = list(df_test.columns)
+            y_test_inv = inverse_transform_predictions(y_test, scaler, df_cols, TARGET_COL)
+            y_pred_inv = inverse_transform_predictions(
+                y_test_pred_scaled, scaler, df_cols, TARGET_COL
+            )
+
+            mse = mean_squared_error(
+                y_test_inv, y_pred_inv, multioutput="uniform_average"
+            )
+            mae = mean_absolute_error(
+                y_test_inv, y_pred_inv, multioutput="uniform_average"
+            )
+            rmse = math.sqrt(mse)
+            r2 = r2_score(y_test_inv, y_pred_inv, multioutput="uniform_average")
+
+            logger.info(
+                f"Metrics for {station_folder} - MAE: {mae:.4f}, MSE: {mse:.4f}, RMSE: {rmse:.4f}, R2: {r2:.4f}"
+            )
+
+            plot_time_series_predictions(y_test_inv, y_pred_inv, HORIZON, station_folder)
+            for day_idx in range(HORIZON):
+                plot_scatter_day(y_test_inv, y_pred_inv, day_idx, station_folder)
+        else:
+            logger.info(
+                f"Not enough test data to form sequences for station: {station_folder}. Skipping evaluation."
+            )
+
+
+# -------------------------------
 # 4. Main Script
 # -------------------------------
 def main():
     np.random.seed(RANDOM_SEED)
     tf.random.set_seed(RANDOM_SEED)
+
+    if TRAIN_PER_FARM:
+        for idx, station in enumerate(STATION_FOLDERS, 1):
+            logger.info(f"[{idx}/{len(STATION_FOLDERS)}] Training {station}")
+            train_for_station(station)
+        logger.info("All done.")
+        return
 
     train_list = []
     test_data_by_station = {}
@@ -304,10 +456,10 @@ def main():
 
     # B) Combine all training data
     if not train_list:
-        print("No training data found.")
+        logger.info("No training data found.")
         return
     df_train_all = pd.concat(train_list, ignore_index=True)
-    print("Combined training shape:", df_train_all.shape)
+    logger.info(f"Combined training shape: {df_train_all.shape}")
 
     # C) Scale the training data (using StandardScaler here, can be changed to MinMaxScaler if desired)
     scaler = StandardScaler()
@@ -325,7 +477,7 @@ def main():
         horizon=HORIZON,
         target_col=TARGET_COL
     )
-    print("Full training sequences:", len(X_train_full))
+    logger.info(f"Full training sequences: {len(X_train_full)}")
 
     # E) Shuffle & split into train/validation sets
     indices = np.arange(len(X_train_full))
@@ -339,8 +491,8 @@ def main():
     X_train = X_train_full[:train_size]
     y_train = y_train_full[:train_size]
 
-    print("Training sequences:", len(X_train))
-    print("Validation sequences:", len(X_val))
+    logger.info(f"Training sequences: {len(X_train)}")
+    logger.info(f"Validation sequences: {len(X_val)}")
 
     # F) Build & train LSTM model with custom R² metric
     num_features = df_train_all.shape[1]
@@ -361,29 +513,29 @@ def main():
         epochs=50,
         batch_size=32,
         callbacks=[early_stop],
-        verbose=1
+        verbose=0
     )
 
     # Save the trained model
     model.save(MODEL_PATH)
-    print(f"Model saved to {MODEL_PATH}")
+    logger.info(f"Model saved: {MODEL_PATH}")
 
     # Save training history as CSV
     history_df = pd.DataFrame(history.history)
     history_csv_path = os.path.join(PLOTS_DIR, "training_history_values.csv")
     history_df.to_csv(history_csv_path, index=False)
-    print(f"Training history values saved to {history_csv_path}")
+    logger.info(f"Training history values saved to {history_csv_path}")
 
     # Plot training history (loss and R²)
     plot_history_path = os.path.join(PLOTS_DIR, "training_history.png")
     plot_training_history(history, plot_history_path)
-    print(f"Training history plot saved to {plot_history_path}")
+    logger.info(f"Training history plot saved to {plot_history_path}")
 
     # G) Evaluate on each station's test set separately
     for station in STATION_FOLDERS:
         df_test_stn = test_data_by_station.get(station, pd.DataFrame())
         if df_test_stn.empty:
-            print(f"No test data for station: {station}. Skipping.")
+            logger.info(f"No test data for station: {station}. Skipping.")
             continue
 
         # Scale test data
@@ -400,7 +552,9 @@ def main():
             target_col=TARGET_COL
         )
         if len(X_test) == 0:
-            print(f"Not enough test data to form sequences for station: {station}. Skipping.")
+            logger.info(
+                f"Not enough test data to form sequences for station: {station}. Skipping."
+            )
             continue
 
         # Predict on test data
@@ -417,11 +571,9 @@ def main():
         rmse = math.sqrt(mse)
         r2 = r2_score(y_test_inv, y_pred_inv, multioutput='uniform_average')
 
-        print(f"\n--- Test Metrics for station: {station} (range: {TEST_START} to {TEST_END}) ---")
-        print(f"MAE:  {mae:.4f}")
-        print(f"MSE:  {mse:.4f}")
-        print(f"RMSE: {rmse:.4f}")
-        print(f"R²:   {r2:.4f}")
+        logger.info(
+            f"Metrics for {station} - MAE: {mae:.4f}, MSE: {mse:.4f}, RMSE: {rmse:.4f}, R2: {r2:.4f}"
+        )
 
         # Plot time-series predictions vs. actual rainfall
         plot_time_series_predictions(y_test_inv, y_pred_inv, HORIZON, station)
@@ -430,7 +582,7 @@ def main():
         for day_idx in range(HORIZON):
             plot_scatter_day(y_test_inv, y_pred_inv, day_idx, station)
 
-    print("\nAll done. End of script.")
+    logger.info("All done.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- support selecting per-farm vs combined training with `TRAIN_PER_FARM`
- implement `train_for_station` to train a model for a single farm
- apply the new logic in `model.py` and `model_rainfall.py`
- streamline logging to identify the farm being trained

## Testing
- `python -m py_compile model.py model_rainfall.py`


------
https://chatgpt.com/codex/tasks/task_e_6857da4f68ac832da25bb8c2d347eb23