### PR TITLE
Improve rainfall pipeline

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,8 +95,8 @@ def fetch_daily_data_for_year(lat, lng, datatype, start_date, end_date, aggregat
     else:
         data = response.json()  # Expected to be a dictionary with ISO-8601 date keys.
         df = pd.DataFrame(list(data.items()), columns=["Date", "Value"])
-        # Convert Date column from string to datetime objects.
-        df["Date"] = pd.to_datetime(df["Date"])
+        # Convert Date column from string to timezone-naive datetime objects.
+        df["Date"] = pd.to_datetime(df["Date"], utc=True).dt.tz_localize(None)
     return df
 
 # -------------------------------
@@ -121,19 +121,25 @@ def main():
             end_date = PARTIAL_END_DATE if (year == END_YEAR and PARTIAL_END_DATE) else f"{year}-12-31"
             print(f"  Year: {year}, Range: {start_date} to {end_date}")
             
-            # Fetch daily data for rainfall, Tmax, and Tmin.
+            # Fetch daily data for rainfall, Tmax, Tmin, humidity, and wind speed.
             df_rain = fetch_daily_data_for_year(lat, lng, "rainfall", start_date, end_date)
             df_tmax = fetch_daily_data_for_year(lat, lng, "temperature", start_date, end_date, aggregation="max")
             df_tmin = fetch_daily_data_for_year(lat, lng, "temperature", start_date, end_date, aggregation="min")
+            df_rh = fetch_daily_data_for_year(lat, lng, "humidity", start_date, end_date)
+            df_wind = fetch_daily_data_for_year(lat, lng, "wind_speed", start_date, end_date)
             
             # Rename the "Value" columns.
             df_rain = df_rain.rename(columns={"Value": "Rainfall (mm)"})
             df_tmax = df_tmax.rename(columns={"Value": "Tmax (°C)"})
             df_tmin = df_tmin.rename(columns={"Value": "Tmin (°C)"})
+            df_rh = df_rh.rename(columns={"Value": "RH (%)"})
+            df_wind = df_wind.rename(columns={"Value": "Wind Speed (m/s)"})
             
             # Merge the DataFrames on the "Date" column using an outer join.
             df_merge = pd.merge(df_rain, df_tmax, on="Date", how="outer")
             df_merge = pd.merge(df_merge, df_tmin, on="Date", how="outer")
+            df_merge = pd.merge(df_merge, df_rh, on="Date", how="outer")
+            df_merge = pd.merge(df_merge, df_wind, on="Date", how="outer")
             df_merge.sort_values("Date", inplace=True)
             
             # Compute Tmean.
@@ -158,11 +164,13 @@ def main():
             # Prepare final DataFrame with desired columns.
             df_merge = df_merge.rename(columns={"Ra_mm": "Ra (mm/day)"})
             final_df = df_merge[[
-                "Date", 
-                "Rainfall (mm)", 
-                "Tmax (°C)", 
-                "Tmin (°C)", 
-                "ET (mm/day)", 
+                "Date",
+                "Rainfall (mm)",
+                "Tmax (°C)",
+                "Tmin (°C)",
+                "RH (%)",
+                "Wind Speed (m/s)",
+                "ET (mm/day)",
                 "Ra (mm/day)"
             ]].copy()
             

--- a/model_rainfall.py
+++ b/model_rainfall.py
@@ -186,9 +186,21 @@ def feature_engineering(df):
     if "Date" in df.columns:
         df["day"] = df["Date"].dt.day
         df["month"] = df["Date"].dt.month
+        # Cyclical month features for seasonality
+        df["month_sin"] = np.sin(2 * np.pi * df["Date"].dt.month / 12)
+        df["month_cos"] = np.cos(2 * np.pi * df["Date"].dt.month / 12)
+
+    # Handle erroneous extremely low Tmin values
+    if "Tmin (°C)" in df.columns:
+        df.loc[df["Tmin (°C)"] < -10, "Tmin (°C)"] = np.nan
+
+    # Log-transform rainfall to stabilize variance
+    if "Rainfall (mm)" in df.columns:
+        df = df[df["Rainfall (mm)"].notna()]
+        df["Rainfall (mm)"] = np.log1p(df["Rainfall (mm)"])
 
     # Drop columns we don't want in the model
-    drop_cols = ["Date", "Latitude", "Longitude", "Station"]
+    drop_cols = ["Date", "Latitude", "Longitude", "Station", "month"]
     for col in drop_cols:
         if col in df.columns:
             df.drop(col, axis=1, inplace=True)
@@ -454,6 +466,8 @@ def train_for_station(station_folder):
     y_train_pred_inv = inverse_transform_predictions(
         y_train_pred_scaled, scaler, df_cols, TARGET_COL
     )
+    y_train_inv = np.expm1(y_train_inv)
+    y_train_pred_inv = np.expm1(y_train_pred_inv)
     train_mae, train_mse, train_rmse, train_r2_avg, train_r2_each = compute_metrics(
         y_train_inv, y_train_pred_inv
     )
@@ -465,6 +479,8 @@ def train_for_station(station_folder):
     y_val_pred_inv = inverse_transform_predictions(
         y_val_pred_scaled, scaler, df_cols, TARGET_COL
     )
+    y_val_inv = np.expm1(y_val_inv)
+    y_val_pred_inv = np.expm1(y_val_pred_inv)
     val_mae, val_mse, val_rmse, val_r2_avg, val_r2_each = compute_metrics(
         y_val_inv, y_val_pred_inv
     )
@@ -517,6 +533,8 @@ def train_for_station(station_folder):
             y_pred_inv = inverse_transform_predictions(
                 y_test_pred_scaled, scaler, df_cols, TARGET_COL
             )
+            y_test_inv = np.expm1(y_test_inv)
+            y_pred_inv = np.expm1(y_pred_inv)
 
             mae, mse, rmse, r2_avg, r2_each = compute_metrics(y_test_inv, y_pred_inv)
 
@@ -731,6 +749,8 @@ def main():
     y_train_pred_inv = inverse_transform_predictions(
         y_train_pred_scaled, scaler, df_cols, TARGET_COL
     )
+    y_train_inv = np.expm1(y_train_inv)
+    y_train_pred_inv = np.expm1(y_train_pred_inv)
     train_mae, train_mse, train_rmse, train_r2_avg, train_r2_each = compute_metrics(
         y_train_inv, y_train_pred_inv
     )
@@ -740,6 +760,8 @@ def main():
     y_val_pred_inv = inverse_transform_predictions(
         y_val_pred_scaled, scaler, df_cols, TARGET_COL
     )
+    y_val_inv = np.expm1(y_val_inv)
+    y_val_pred_inv = np.expm1(y_val_pred_inv)
     val_mae, val_mse, val_rmse, val_r2_avg, val_r2_each = compute_metrics(
         y_val_inv, y_val_pred_inv
     )
@@ -795,6 +817,8 @@ def main():
         y_pred_inv = inverse_transform_predictions(
             y_test_pred_scaled, scaler, df_cols, TARGET_COL
         )
+        y_test_inv = np.expm1(y_test_inv)
+        y_pred_inv = np.expm1(y_pred_inv)
 
         mae, mse, rmse, r2_avg, r2_each = compute_metrics(y_test_inv, y_pred_inv)
 


### PR DESCRIPTION
## Summary
- log-transform rainfall target and add month_sin/month_cos cyclic features
- clean Tmin outliers
- invert log transform when evaluating
- fetch humidity and wind speed in `main.py`
- add humidity and wind columns to per-station CSVs
- convert API dates to timezone naive to avoid merge errors

## Testing
- `python3 -m py_compile main.py model_rainfall.py`


------
https://chatgpt.com/codex/tasks/task_e_685b3adc4740832d90ae2f867e0f0038