### PR TITLE
Add rainfall training analysis tools

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,6 +21,7 @@ STATION_FOLDERS = [
 
 TRAIN_PER_FARM = True
 MODELS_DIR = "models"
+TRAINING_ANALYSIS_DIR = "training_analysis"
 BASE_DIR = "farm_data"
 
 TRAIN_RATIO = 0.70

--- a/model_rainfall.py
+++ b/model_rainfall.py
@@ -20,6 +20,7 @@ from config import (
     STATION_FOLDERS,
     TRAIN_PER_FARM,
     MODELS_DIR,
+    TRAINING_ANALYSIS_DIR,
     BASE_DIR,
     TRAIN_RATIO,
     VAL_RATIO,
@@ -44,6 +45,7 @@ from training_utils import (
 )
 
 os.makedirs(MODELS_DIR, exist_ok=True)
+os.makedirs(TRAINING_ANALYSIS_DIR, exist_ok=True)
 
 # Scikit-learn
 from sklearn.model_selection import train_test_split
@@ -228,7 +230,11 @@ def train_for_station(station_folder):
     os.makedirs(station_plot_dir, exist_ok=True)
 
     history_csv_path = os.path.join(station_plot_dir, "training_history_values.csv")
-    pd.DataFrame(history.history).to_csv(history_csv_path, index=False)
+    history_df = pd.DataFrame(history.history)
+    history_df.to_csv(history_csv_path, index=False)
+
+    analysis_csv_path = os.path.join(TRAINING_ANALYSIS_DIR, f"{station_folder}_history.csv")
+    history_df.to_csv(analysis_csv_path, index=False)
 
     plot_history_path = os.path.join(station_plot_dir, "training_history.png")
     plot_training_history(history, plot_history_path)
@@ -528,6 +534,9 @@ def main():
     history_df.to_csv(history_csv_path, index=False)
     print(f"Training history values saved to {history_csv_path}")
 
+    analysis_csv_path = os.path.join(TRAINING_ANALYSIS_DIR, "combined_history.csv")
+    history_df.to_csv(analysis_csv_path, index=False)
+
     # Plot training history (loss and R²)
     plot_history_path = os.path.join(PLOTS_DIR, "training_history.png")
     plot_training_history(history, plot_history_path)
@@ -662,6 +671,10 @@ def main():
     test_df.to_csv(test_path, index=False)
     print(f"\nTraining/validation metrics saved to {train_val_path}")
     print(f"Test metrics saved to {test_path}")
+
+    summary_path = os.path.join(TRAINING_ANALYSIS_DIR, "summary.csv")
+    summary_df = train_val_df.merge(test_df, on="farm", how="left")
+    summary_df.to_csv(summary_path, index=False)
 
     print("\nAll done. End of script.")
 

--- a/training_analysis/generate_training_summary.py
+++ b/training_analysis/generate_training_summary.py
@@ -1,0 +1,48 @@
+import os
+import pandas as pd
+
+
+def analyze_histories(directory="."):
+    records = []
+    for fname in os.listdir(directory):
+        if fname.endswith("_history.csv"):
+            path = os.path.join(directory, fname)
+            try:
+                df = pd.read_csv(path)
+            except Exception as e:
+                print(f"Could not read {path}: {e}")
+                continue
+            session = fname.rsplit("_history.csv", 1)[0]
+            epochs = len(df)
+            train_loss_last = df.get("loss", pd.Series([None])).iloc[-1]
+            val_loss_last = df.get("val_loss", pd.Series([None])).iloc[-1]
+            overfit = (
+                val_loss_last - train_loss_last
+                if train_loss_last is not None and val_loss_last is not None
+                else None
+            )
+            improvement = (
+                df.get("val_loss", pd.Series([None])).iloc[0] - val_loss_last
+                if val_loss_last is not None and "val_loss" in df
+                else None
+            )
+            records.append(
+                {
+                    "session": session,
+                    "epochs": epochs,
+                    "train_loss_last": train_loss_last,
+                    "val_loss_last": val_loss_last,
+                    "val_minus_train": overfit,
+                    "val_loss_reduction": improvement,
+                }
+            )
+    if records:
+        summary_df = pd.DataFrame(records)
+        summary_df.to_csv(os.path.join(directory, "history_analysis.csv"), index=False)
+        print(f"Summary saved to {os.path.join(directory, 'history_analysis.csv')}")
+    else:
+        print("No history files found for analysis.")
+
+
+if __name__ == "__main__":
+    analyze_histories(os.path.dirname(__file__))


### PR DESCRIPTION
## Summary
- add TRAINING_ANALYSIS_DIR config constant
- store rainfall training history and metrics in new `training_analysis` folder
- generate summary CSV across sessions
- add script for analyzing training histories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d273f8ecc832d8f459189fdbbb0f5