### PR TITLE
Implement environment-configurable API and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Hawaii ET/Rain Forecast
+
+This project provides evapotranspiration and rainfall forecasts for various farms in Hawaii.  
+The web application is built with Streamlit and exposes a simple API using Flask.
+
+## Environment Variables
+
+The application relies on several environment variables which can be placed in a `.env` file:
+
+- `HCDP_API_TOKEN` – **required** token for the HCDP data API.
+- `FETCH_TOTAL_DAYS` – number of days of historical data to pull from the API (default: `50`).
+- `DB_FILE` – path to the SQLite database file (default: `hawaii-et-rain-website/hawaii_daily_process.db`).
+- `SCHEDULE_TIME` – daily prediction time in `HH:MM` 24‑hour format (default: `09:37`).
+- `MAPBOX_TOKEN` – optional token for Mapbox tiles used in PyDeck maps.
+
+## Running the Streamlit App
+
+```bash
+pip install -r hawaii-et-rain-website/requirements.txt
+streamlit run hawaii-et-rain-website/hawaii_app.py
+```
+
+## Running the API Server
+
+```bash
+pip install -r hawaii-et-rain-website/requirements.txt
+python hawaii-et-rain-website/hawaii_api.py
+```
+
+The API exposes `/api/predict?farm=<FARM_NAME>&format=json|csv`.

--- a/hawaii-et-rain-website/hawaii_api.py
+++ b/hawaii-et-rain-website/hawaii_api.py
@@ -1,0 +1,56 @@
+from flask import Flask, request, jsonify, Response
+import pandas as pd
+from dotenv import load_dotenv
+from hawaii_web import fetch_and_predict_hawaii, farm_coords, HORIZON
+
+load_dotenv()
+
+app = Flask(__name__)
+
+@app.route('/api/predict')
+def api_predict():
+    """Return forecast data for a farm as JSON or CSV."""
+    farm = request.args.get('farm')
+    out_format = request.args.get('format', 'json').lower()
+
+    if not farm or farm not in farm_coords:
+        return jsonify({'error': 'Invalid or missing farm parameter'}), 400
+
+    results = fetch_and_predict_hawaii(farm)
+    if not results:
+        return jsonify({'error': 'No prediction available'}), 500
+
+    output = {
+        'query_farm': farm,
+        'prediction_farm': results['farm'],
+        'latitude': results['latitude'],
+        'longitude': results['longitude'],
+        'last_data_date': results['last_data_date'],
+        'forecast': [
+            {
+                'date': results['prediction_dates'][i],
+                'et_mm_day': results['et_mm_day'][i],
+                'rain_mm': results['rain_mm'][i],
+            } for i in range(HORIZON)
+        ]
+    }
+
+    if out_format == 'csv':
+        rows = []
+        for item in output['forecast']:
+            rows.append({
+                'farm': output['prediction_farm'],
+                'latitude': output['latitude'],
+                'longitude': output['longitude'],
+                'last_data_date': output['last_data_date'],
+                'forecast_date': item['date'],
+                'et_mm_day': item['et_mm_day'],
+                'rain_mm': item['rain_mm'],
+            })
+        df = pd.DataFrame(rows)
+        return Response(df.to_csv(index=False), mimetype='text/csv')
+
+    return jsonify(output)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/hawaii-et-rain-website/hawaii_app.py
+++ b/hawaii-et-rain-website/hawaii_app.py
@@ -23,14 +23,17 @@ load_dotenv()
 
 
 
-
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-DB_FILE = os.path.join(BASE_DIR, 'hawaii_daily_process.db')
+# Database file is configurable via env; defaults to local file in website dir
+DB_FILE = os.getenv('DB_FILE', os.path.join(BASE_DIR, 'hawaii_daily_process.db'))
 DEFAULT_HOST = "localhost"
 HOST = os.getenv('HOST_IP', DEFAULT_HOST)
-DEFAULT_LAT = 20.8
-DEFAULT_LON = -157.5
-DEFAULT_ZOOM = 7
+
+# Optional Mapbox token for PyDeck visualizations
+MAPBOX_TOKEN = os.getenv('MAPBOX_TOKEN')
+if MAPBOX_TOKEN:
+    pdk.settings.mapbox_api_key = MAPBOX_TOKEN
+
 
 farm_names = list(farm_coords.keys())
 task_running = False
@@ -186,7 +189,11 @@ def daily_prediction_task(list_of_farms):
         print("Task is already running. Skipping.")
 
 def schedule_tasks():
-    schedule.every().day.at("09:37").do(functools.partial(daily_prediction_task, farm_names))
+    # Time of day for the daily prediction task in HH:MM (24h) format
+    schedule_time = os.getenv("SCHEDULE_TIME", "09:37")
+    schedule.every().day.at(schedule_time).do(
+        functools.partial(daily_prediction_task, farm_names)
+    )
 
 
     while True:

--- a/hawaii-et-rain-website/hawaii_web.py
+++ b/hawaii-et-rain-website/hawaii_web.py
@@ -51,13 +51,10 @@ MODELS_DIR = os.path.join(BASE_DIR, "..", CONFIG_MODELS_DIR)
 models_cache = {}
 scalers_cache = {}
 
-# Caches for loaded models and scalers to avoid re-loading on each request
-models_cache = {}
-scalers_cache = {}
-
 WINDOW_SIZE = CONFIG_WINDOW_SIZE
 HORIZON = CONFIG_HORIZON
-FETCH_TOTAL_DAYS = 50
+# Number of days of data to fetch from the HCDP API. Can be overridden via env var
+FETCH_TOTAL_DAYS = int(os.getenv("FETCH_TOTAL_DAYS", "50"))
 
 
 FEATURE_COLS_FOR_SCALER = ['Rainfall (mm)', 'Tmax (°C)', 'Tmin (°C)', 'ET (mm/day)', 'Ra (mm/day)', 'day', 'month']

--- a/hawaii-et-rain-website/requirements.txt
+++ b/hawaii-et-rain-website/requirements.txt
@@ -19,3 +19,4 @@ streamlit_option_menu
 streamlit-extras
 tensorflow
 # time
+Flask


### PR DESCRIPTION
## Summary
- clean up redundant caches and make fetch period configurable
- expose database path, schedule time and Mapbox token via environment variables
- remove unused map defaults
- add Flask API server for `/api/predict`
- document environment variables and usage
- include Flask dependency

## Testing
- `python -m py_compile hawaii-et-rain-website/hawaii_web.py hawaii-et-rain-website/hawaii_app.py hawaii-et-rain-website/hawaii_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6863501e2348832db8b3245f53939a7e