### PR TITLE
Improve API and add concise docs

### DIFF
--- a/hawaii-et-rain-website/hawaii_api.py
+++ b/hawaii-et-rain-website/hawaii_api.py
@@ -1,3 +1,7 @@
+"""Simple Flask API exposing ET and rainfall predictions."""
+
+from typing import Any, Dict, List
+
 from flask import Flask, request, jsonify, Response
 import pandas as pd
 from dotenv import load_dotenv
@@ -7,8 +11,19 @@ load_dotenv()
 
 app = Flask(__name__)
 
+
+@app.route('/')
+def index() -> dict:
+    """Return available endpoints for quick reference."""
+    return {
+        'endpoints': [
+            '/api/predict?farm=<NAME>&format=json|csv',
+            '/api/farms'
+        ]
+    }
+
 @app.route('/api/predict')
-def api_predict():
+def api_predict() -> tuple[Response | Any, int] | Response:
     """Return forecast data for a farm as JSON or CSV."""
     farm = request.args.get('farm')
     out_format = request.args.get('format', 'json').lower()
@@ -51,6 +66,12 @@ def api_predict():
         return Response(df.to_csv(index=False), mimetype='text/csv')
 
     return jsonify(output)
+
+
+@app.route('/api/farms')
+def api_farms() -> Dict[str, Dict[str, float]]:
+    """Return mapping of farm names to their coordinates."""
+    return jsonify(farm_coords)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8000)

--- a/hawaii-et-rain-website/hawaii_app.py
+++ b/hawaii-et-rain-website/hawaii_app.py
@@ -1,3 +1,5 @@
+"""Streamlit dashboard for displaying Hawaiian ET and rainfall forecasts."""
+
 import streamlit as st
 import pandas as pd
 import numpy as np
@@ -86,17 +88,22 @@ if api_farm:
 
 
 
-def init_db():
+def init_db() -> None:
+    """Create the SQLite table used to store processed predictions."""
     conn = sqlite3.connect(DB_FILE)
     c = conn.cursor()
-    c.execute('''CREATE TABLE IF NOT EXISTS processed_data
+    c.execute(
+        '''CREATE TABLE IF NOT EXISTS processed_data
                 (timestamp TEXT, farm TEXT, latitude REAL, longitude REAL,
-                 pred_date TEXT, et_pred REAL, rain_pred REAL, last_data_date TEXT)''')
+                 pred_date TEXT, et_pred REAL, rain_pred REAL, last_data_date TEXT)'''
+    )
     conn.commit()
     conn.close()
 
-def save_to_db(results):
-    if not results: return
+def save_to_db(results: dict) -> None:
+    """Persist a prediction result dictionary to the database."""
+    if not results:
+        return
     conn = sqlite3.connect(DB_FILE)
     c = conn.cursor()
     ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/hawaii-et-rain-website/hawaii_web.py
+++ b/hawaii-et-rain-website/hawaii_web.py
@@ -1,3 +1,5 @@
+"""Utility functions used by the Streamlit app and API server."""
+
 import os
 import math
 import requests
@@ -9,6 +11,7 @@ import joblib
 import tensorflow as tf
 from tensorflow.keras.models import load_model
 import tensorflow.keras.backend as K
+from typing import Any, Tuple, Optional
 from dotenv import load_dotenv
 from config import MODELS_DIR as CONFIG_MODELS_DIR, WINDOW_SIZE as CONFIG_WINDOW_SIZE, HORIZON as CONFIG_HORIZON
 
@@ -80,8 +83,9 @@ def sanitize_farm_name(farm_name: str) -> str:
                      .replace(")", ""))
 
 
-def load_models_for_farm(farm_name):
-    """Load ET/Rain models and scalers for a specific farm, using caches when available."""
+
+def load_models_for_farm(farm_name: str) -> Tuple[Optional[tf.keras.Model], Optional[tf.keras.Model], Optional[Any], Optional[Any]]:
+    """Load ET and rainfall models along with their scalers for a farm."""
     if farm_name in models_cache and farm_name in scalers_cache:
         return (models_cache[farm_name].get('et'),
                 models_cache[farm_name].get('rain'),
@@ -258,7 +262,8 @@ def inverse_transform_predictions(y_scaled, target_scaler, feature_column_order,
     return inversed_target_values.reshape(1, horizon) 
 
 
-def fetch_and_predict_hawaii(farm_name):
+def fetch_and_predict_hawaii(farm_name: str) -> Optional[dict]:
+    """Fetch recent data from the API and return predictions for ``farm_name``."""
 
     model_et, model_rain, scaler_et, scaler_rain = load_models_for_farm(farm_name)
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+"""Data ingestion script for downloading raw weather data."""
+
 import os
 import math
 import requests


### PR DESCRIPTION
## Summary
- extend the API with a farm listing endpoint and add an index route
- add docstrings and type hints across the application
- document Streamlit dashboard and data ingestion script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68636603f910832d8da4b886318cb25e